### PR TITLE
updated sanitzer to return default supported cards for apple/google pay when none provided

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -46,7 +46,6 @@ function App(): JSX.Element {
                   applePay: {
                     enabled: true,
                     merchantIdentifier: 'merchant.tyro-pay-api-sample-app',
-                    supportedNetworks: ['visa', 'amex'],
                   },
                 },
                 styleProps: {

--- a/example/src/Checkout.tsx
+++ b/example/src/Checkout.tsx
@@ -1,4 +1,4 @@
-import { View, Text, StyleSheet, ActivityIndicator, ScrollView } from 'react-native';
+import { View, Text, StyleSheet, ScrollView } from 'react-native';
 import React, { useEffect, useState } from 'react';
 import { useTyro, PaySheet } from '@tyro/tyro-pay-api-react-native';
 import { createPayRequest } from './clients/pay-request-client';
@@ -21,7 +21,6 @@ const CheckOut = ({ route }: Props): JSX.Element => {
     submitPayForm,
     isSubmitting,
     isPayRequestReady,
-    isPayRequestLoading,
   } = useTyro();
 
   useEffect(() => {

--- a/src/utils/sanitizers.spec.ts
+++ b/src/utils/sanitizers.spec.ts
@@ -1,5 +1,11 @@
 import { CardTypeNames } from '../@types/card-types';
-import { SupportedNetworks, SupportedNetworksApplePay, SupportedNetworksGooglePay } from '../@types/network-types';
+import {
+  SupportedCardsApplePay,
+  SupportedCardsGooglePay,
+  SupportedNetworks,
+  SupportedNetworksApplePay,
+  SupportedNetworksGooglePay,
+} from '../@types/network-types';
 import {
   parseSupportedNetworks,
   parseSupportedNetworksApplePay,
@@ -30,9 +36,11 @@ const defaultedOptionsExpectation = {
   options: {
     applePay: {
       enabled: expect.any(Boolean),
+      supportedNetworks: [...SupportedCardsApplePay],
     },
     googlePay: {
       enabled: expect.any(Boolean),
+      supportedNetworks: [...SupportedCardsGooglePay],
     },
     creditCardForm: {
       enabled: true,
@@ -130,7 +138,7 @@ describe('sanitizers', () => {
           },
         },
       });
-      expect(result.options.applePay).toEqual({ enabled: false });
+      expect(result.options.applePay).toEqual({ enabled: false, supportedNetworks: [...SupportedCardsApplePay] });
     });
 
     it('disables googlePay on iOS platform', () => {
@@ -143,7 +151,7 @@ describe('sanitizers', () => {
           },
         },
       });
-      expect(result.options.googlePay).toEqual({ enabled: false });
+      expect(result.options.googlePay).toEqual({ enabled: false, supportedNetworks: [...SupportedCardsGooglePay] });
     });
   });
   describe('parseSupportedNetworks', () => {
@@ -193,6 +201,10 @@ describe('sanitizers', () => {
       const parsed = parseSupportedNetworksApplePay(invalidSN);
       expect(parsed).toEqual([CardTypeNames.MASTERCARD, CardTypeNames.VISA, CardTypeNames.MAESTRO]);
     });
+    it('should return the default supported cards when none supplied in options', () => {
+      const parsed = parseSupportedNetworksApplePay(undefined);
+      expect(parsed).toEqual([...SupportedCardsApplePay]);
+    });
   });
 
   describe('parseSupportedNetworksGooglePay', () => {
@@ -212,6 +224,10 @@ describe('sanitizers', () => {
     it('should clean the array when input contains valid value', () => {
       const parsed = parseSupportedNetworksGooglePay(invalidSN);
       expect(parsed).toEqual([CardTypeNames.MASTERCARD, CardTypeNames.VISA]);
+    });
+    it('should return the default supported cards when none supplied in options', () => {
+      const parsed = parseSupportedNetworksGooglePay(undefined);
+      expect(parsed).toEqual([...SupportedCardsGooglePay]);
     });
   });
 });

--- a/src/utils/sanitizers.spec.ts
+++ b/src/utils/sanitizers.spec.ts
@@ -6,12 +6,7 @@ import {
   SupportedNetworksApplePay,
   SupportedNetworksGooglePay,
 } from '../@types/network-types';
-import {
-  parseSupportedNetworks,
-  parseSupportedNetworksApplePay,
-  parseSupportedNetworksGooglePay,
-  sanitizeOptions,
-} from './sanitizers';
+import { parseSupportedNetworks, parseWalletSupportedNetworks, sanitizeOptions } from './sanitizers';
 import { ThemeNames } from '../@types/theme-styles';
 import { TyroPayOptionsProps } from '../@types/definitions';
 import { Platform } from 'react-native';
@@ -183,51 +178,59 @@ describe('sanitizers', () => {
       expect(parsedSupportedNetworks).toEqual([CardTypeNames.VISA]);
     });
   });
-  describe('parseSupportedNetworksApplePay', () => {
-    const validSN = [CardTypeNames.VISA, CardTypeNames.MASTERCARD] as SupportedNetworksApplePay[];
-    const invalidSN = [
-      CardTypeNames.VISA,
-      CardTypeNames.MASTERCARD,
-      CardTypeNames.MAESTRO,
-      CardTypeNames.DINERS,
-      'random',
-    ] as unknown as SupportedNetworksApplePay[];
+  describe('parseWalletSupportedNetworks', () => {
+    describe('Apple Pay', () => {
+      const validSN = [CardTypeNames.VISA, CardTypeNames.MASTERCARD] as SupportedNetworksApplePay[];
+      const invalidSN = [
+        CardTypeNames.VISA,
+        CardTypeNames.MASTERCARD,
+        CardTypeNames.MAESTRO,
+        CardTypeNames.DINERS,
+        'random',
+      ] as unknown as SupportedNetworksApplePay[];
+      it('should return original when input is valid', () => {
+        const parsed = parseWalletSupportedNetworks(validSN, [...SupportedCardsApplePay]);
+        expect(parsed).toEqual([CardTypeNames.MASTERCARD, CardTypeNames.VISA]);
+      });
+      it('should clean the array when input contains valid value', () => {
+        const parsed = parseWalletSupportedNetworks(invalidSN, [...SupportedCardsApplePay]);
+        expect(parsed).toEqual([CardTypeNames.MASTERCARD, CardTypeNames.VISA, CardTypeNames.MAESTRO]);
+      });
+      it('should return the default supported cards when none supplied in options', () => {
+        const parsed = parseWalletSupportedNetworks(undefined, [...SupportedCardsApplePay]);
+        expect(parsed).toEqual([...SupportedCardsApplePay]);
+      });
+      it('should return the default supported cards when supported card not in supported cards for Apple Pay', () => {
+        const parsed = parseWalletSupportedNetworks(['diners'], [...SupportedCardsApplePay]);
+        expect(parsed).toEqual([...SupportedCardsApplePay]);
+      });
+    });
+    describe('Google Pay', () => {
+      const validSN = [CardTypeNames.VISA, CardTypeNames.MASTERCARD] as SupportedNetworksGooglePay[];
+      const invalidSN = [
+        CardTypeNames.VISA,
+        CardTypeNames.MASTERCARD,
+        CardTypeNames.MAESTRO,
+        CardTypeNames.DINERS,
+        'random',
+      ] as unknown as SupportedNetworksGooglePay[];
 
-    it('should return original when input is valid', () => {
-      const parsed = parseSupportedNetworksApplePay(validSN);
-      expect(parsed).toEqual([CardTypeNames.MASTERCARD, CardTypeNames.VISA]);
-    });
-    it('should clean the array when input contains valid value', () => {
-      const parsed = parseSupportedNetworksApplePay(invalidSN);
-      expect(parsed).toEqual([CardTypeNames.MASTERCARD, CardTypeNames.VISA, CardTypeNames.MAESTRO]);
-    });
-    it('should return the default supported cards when none supplied in options', () => {
-      const parsed = parseSupportedNetworksApplePay(undefined);
-      expect(parsed).toEqual([...SupportedCardsApplePay]);
-    });
-  });
-
-  describe('parseSupportedNetworksGooglePay', () => {
-    const validSN = [CardTypeNames.VISA, CardTypeNames.MASTERCARD] as SupportedNetworksGooglePay[];
-    const invalidSN = [
-      CardTypeNames.VISA,
-      CardTypeNames.MASTERCARD,
-      CardTypeNames.MAESTRO,
-      CardTypeNames.DINERS,
-      'random',
-    ] as unknown as SupportedNetworksGooglePay[];
-
-    it('should return original when input is valid', () => {
-      const parsed = parseSupportedNetworksGooglePay(validSN);
-      expect(parsed).toEqual([CardTypeNames.MASTERCARD, CardTypeNames.VISA]);
-    });
-    it('should clean the array when input contains valid value', () => {
-      const parsed = parseSupportedNetworksGooglePay(invalidSN);
-      expect(parsed).toEqual([CardTypeNames.MASTERCARD, CardTypeNames.VISA]);
-    });
-    it('should return the default supported cards when none supplied in options', () => {
-      const parsed = parseSupportedNetworksGooglePay(undefined);
-      expect(parsed).toEqual([...SupportedCardsGooglePay]);
+      it('should return original when input is valid', () => {
+        const parsed = parseWalletSupportedNetworks(validSN, [...SupportedCardsGooglePay]);
+        expect(parsed).toEqual([CardTypeNames.MASTERCARD, CardTypeNames.VISA]);
+      });
+      it('should clean the array when input contains valid value', () => {
+        const parsed = parseWalletSupportedNetworks(invalidSN, [...SupportedCardsGooglePay]);
+        expect(parsed).toEqual([CardTypeNames.MASTERCARD, CardTypeNames.VISA]);
+      });
+      it('should return the default supported cards when none supplied in options', () => {
+        const parsed = parseWalletSupportedNetworks(undefined, [...SupportedCardsGooglePay]);
+        expect(parsed).toEqual([...SupportedCardsGooglePay]);
+      });
+      it('should return the default supported cards when supported cards not in supported cards for Google Pay', () => {
+        const parsed = parseWalletSupportedNetworks(['maestro'], [...SupportedCardsGooglePay]);
+        expect(parsed).toEqual([...SupportedCardsGooglePay]);
+      });
     });
   });
 });

--- a/src/utils/sanitizers.ts
+++ b/src/utils/sanitizers.ts
@@ -60,12 +60,15 @@ export const sanitizeOptions = (options: TyroPayOptionsProps): TyroPayOptions =>
   useOptions.options.creditCardForm.supportedNetworks = supportedNetworks ?? undefined;
 
   // Parse walletPay supportedNetworks
-  useOptions.options.applePay.supportedNetworks = parseSupportedNetworksApplePay(
-    useOptions?.options?.applePay?.supportedNetworks
-  );
-  useOptions.options.googlePay.supportedNetworks = parseSupportedNetworksGooglePay(
-    useOptions?.options?.googlePay?.supportedNetworks
-  );
+  useOptions.options.applePay.supportedNetworks = parseWalletSupportedNetworks(
+    useOptions?.options?.applePay?.supportedNetworks,
+    [...SupportedCardsApplePay]
+  ) as SupportedNetworksApplePay[];
+
+  useOptions.options.googlePay.supportedNetworks = parseWalletSupportedNetworks(
+    useOptions?.options?.googlePay?.supportedNetworks,
+    [...SupportedCardsGooglePay]
+  ) as SupportedNetworksGooglePay[];
 
   // Apply theme defaults
   if (!useOptions?.theme || !Object.values(ThemeNames).includes(useOptions.theme as ThemeNames)) {
@@ -113,18 +116,13 @@ export const parseSupportedNetworks = (
     : null;
 };
 
-export const parseSupportedNetworksApplePay = (
-  fromOptions: SupportedNetworksApplePay[] | undefined
-): SupportedNetworksApplePay[] => {
-  return Array.isArray(fromOptions)
-    ? (SupportedCardsApplePay.filter((value) => fromOptions.includes(value)) as SupportedNetworksApplePay[])
-    : [...SupportedCardsApplePay];
-};
-
-export const parseSupportedNetworksGooglePay = (
-  fromOptions: SupportedNetworksGooglePay[] | undefined
-): SupportedNetworksGooglePay[] => {
-  return Array.isArray(fromOptions)
-    ? (SupportedCardsGooglePay.filter((value) => fromOptions.includes(value)) as SupportedNetworksGooglePay[])
-    : [...SupportedCardsGooglePay];
+export const parseWalletSupportedNetworks = (
+  fromOptions: SupportedNetworks[] | undefined,
+  supportedWalletNetworks: SupportedNetworksApplePay[] | SupportedNetworksGooglePay[]
+): SupportedNetworksApplePay[] | SupportedNetworksGooglePay[] => {
+  let supportedNetworks;
+  if (Array.isArray(fromOptions)) {
+    supportedNetworks = supportedWalletNetworks.filter((value) => fromOptions.includes(value));
+  }
+  return supportedNetworks?.length > 0 ? supportedNetworks : [...supportedWalletNetworks];
 };

--- a/src/utils/sanitizers.ts
+++ b/src/utils/sanitizers.ts
@@ -115,16 +115,16 @@ export const parseSupportedNetworks = (
 
 export const parseSupportedNetworksApplePay = (
   fromOptions: SupportedNetworksApplePay[] | undefined
-): SupportedNetworksApplePay[] | undefined => {
+): SupportedNetworksApplePay[] => {
   return Array.isArray(fromOptions)
     ? (SupportedCardsApplePay.filter((value) => fromOptions.includes(value)) as SupportedNetworksApplePay[])
-    : undefined;
+    : [...SupportedCardsApplePay];
 };
 
 export const parseSupportedNetworksGooglePay = (
   fromOptions: SupportedNetworksGooglePay[] | undefined
-): SupportedNetworksGooglePay[] | undefined => {
+): SupportedNetworksGooglePay[] => {
   return Array.isArray(fromOptions)
     ? (SupportedCardsGooglePay.filter((value) => fromOptions.includes(value)) as SupportedNetworksGooglePay[])
-    : undefined;
+    : [...SupportedCardsGooglePay];
 };


### PR DESCRIPTION
Was causing an error when initiating the pay sheet on iOS devices when no supported cards were specified for Apple Pay. 
Updating to allow a partner to not have to specify the supported cards for Apple Pay to be consistent with the Docs