### PR TITLE
pla-6993: Clean up init

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7332,12 +7332,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -10164,9 +10164,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -19482,9 +19482,9 @@
       }
     },
     "node_modules/react-native/node_modules/ws": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.2.tgz",
-      "integrity": "sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==",
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
+      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
       "dev": true,
       "dependencies": {
         "async-limiter": "~1.0.0"
@@ -21587,9 +21587,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "engines": {
         "node": ">=8.3.0"

--- a/src/@types/message-types.ts
+++ b/src/@types/message-types.ts
@@ -11,7 +11,7 @@ export enum ErrorMessageType {
   INVALID_PAY_SECRET = 'INVALID_PAY_SECRET',
   NOT_INITIALISED = 'NOT_INITIALISED',
   PAYMENT_FAILED = 'PAYMENT_FAILED',
-  NO_FORM = 'NO_FORM',
+  MISSING_MERCHANT_CONFIG = 'MISSING_MERCHANT_CONFIG',
   INVALID_CARD_TYPE = 'INVALID_CARD_TYPE',
   INVALID_CARD_DETAILS = 'INVALID_CARD_DETAILS',
   SERVER_ERROR = 'SERVER_ERROR',
@@ -43,9 +43,9 @@ export const TyroErrorMessages: Record<ErrorMessageType, TyroErrorMessage> = {
     type: ErrorMessageType.PAYMENT_FAILED,
     message: 'Payment failed',
   },
-  [ErrorMessageType.NO_FORM]: {
-    type: ErrorMessageType.NO_FORM,
-    message: 'No form',
+  [ErrorMessageType.MISSING_MERCHANT_CONFIG]: {
+    type: ErrorMessageType.MISSING_MERCHANT_CONFIG,
+    message: 'TyroProvider Failed to init due to missing Google and/or Apple Pay merchant details',
   },
   [ErrorMessageType.INVALID_CARD_TYPE]: {
     type: ErrorMessageType.INVALID_CARD_TYPE,

--- a/src/TyroSDK.ts
+++ b/src/TyroSDK.ts
@@ -1,8 +1,6 @@
 import { getPayRequest } from './clients/pay-request-client';
 import { ClientPayRequestResponse, PayRequestStatus } from './@types/pay-request-types';
 import { TyroPayOptions, TyroPayOptionsKeys } from './@types/definitions';
-import { isAndroid } from './utils/helpers';
-import { Platform } from 'react-native';
 import { NativeModules } from 'react-native';
 import { WalletPaymentInitResult, WalletPaymentResult } from './@types/wallet-payment-result';
 
@@ -11,17 +9,6 @@ const { TyroPaySdkModule } = NativeModules;
 class TyroSDK {
   private payRequest: ClientPayRequestResponse | undefined;
   private payStatus: PayRequestStatus | undefined;
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  init = async (options: TyroPayOptions): Promise<void> => {
-    // eslint-disable-next-line no-empty
-    if (isAndroid(Platform.OS)) {
-      // eslint-disable-next-line no-empty
-    } else {
-    }
-
-    // TO DO: initialise native ios with config
-  };
 
   initAndVerifyPaySecret = async (paySecret: string, liveMode: boolean): Promise<ClientPayRequestResponse> => {
     if (!paySecret) {

--- a/src/TyroSharedContext.tsx
+++ b/src/TyroSharedContext.tsx
@@ -74,30 +74,21 @@ const TyroProvider = ({ children, options }: TyroPayContext): JSX.Element => {
   });
 
   const missingMerchantIdentifier = (options: TyroPayOptionsOptionsProps): boolean => {
-    if (
+    return !!(
       options[TyroPayOptionsOptionsKeys.applePay]?.[TyroPayApplePayOptionKeys.enabled] &&
       !options[TyroPayOptionsOptionsKeys.applePay]?.[TyroPayApplePayOptionKeys.merchantIdentifier]
-    ) {
-      return true;
-    }
-    return false;
+    );
   };
 
   const missingMerchantName = (options: TyroPayOptionsOptionsProps): boolean => {
-    if (
+    return !!(
       options[TyroPayOptionsOptionsKeys.googlePay]?.[TyroPayGooglePayOptionKeys.enabled] &&
       !options[TyroPayOptionsOptionsKeys.googlePay][TyroPayGooglePayOptionKeys.merchantName]
-    ) {
-      return true;
-    }
-    return false;
+    );
   };
 
   const missingMerchantDetails = (options: TyroPayOptionsOptionsProps): boolean => {
-    if (missingMerchantIdentifier(options) || missingMerchantName(options)) {
-      return true;
-    }
-    return false;
+    return missingMerchantIdentifier(options) || missingMerchantName(options);
   };
 
   const initProvider = (cleanedOptions: TyroPayOptions): void => {

--- a/src/tests/PaySheet.spec.tsx
+++ b/src/tests/PaySheet.spec.tsx
@@ -42,6 +42,9 @@ jest.mock('../@types/images.tsx', () => {
   };
 });
 
+const merchantIdentifier = 'merId';
+const merchantName = 'merName';
+
 const renderWithProvider = async (component, options: TyroPayOptionsProps): Promise<any> => {
   return render(<TyroProvider options={options}>{component}</TyroProvider>);
 };
@@ -1203,10 +1206,11 @@ describe('PaySheet', () => {
               options: {
                 googlePay: {
                   enabled: false,
+                  merchantName,
                 },
                 applePay: {
                   enabled: true,
-                  merchantIdentifier: 'merchantIdentifier',
+                  merchantIdentifier,
                   supportedNetworks: ['visa'],
                 },
               },
@@ -1226,9 +1230,11 @@ describe('PaySheet', () => {
               options: {
                 googlePay: {
                   enabled: true,
+                  merchantName,
                 },
                 applePay: {
                   enabled: true,
+                  merchantIdentifier,
                 },
               },
               styleProps: { walletPaymentsDividerText: 'My Custom Divider Text', showSupportedCards: false },
@@ -1247,9 +1253,11 @@ describe('PaySheet', () => {
               options: {
                 googlePay: {
                   enabled: true,
+                  merchantName,
                 },
                 applePay: {
                   enabled: true,
+                  merchantIdentifier,
                 },
               },
               styleProps: { walletPaymentsDividerEnabled: false, showSupportedCards: false },

--- a/src/tests/TyroSDK.spec.ts
+++ b/src/tests/TyroSDK.spec.ts
@@ -1,5 +1,4 @@
 import tyroSdk from '../TyroSDK';
-import { defaultOptions } from '../@types/default';
 import {
   CaptureMethod,
   ClientPayRequestResponse,
@@ -48,10 +47,6 @@ global.fetch = jest.fn(() =>
 describe('TyroSDK', () => {
   beforeAll(() => {
     jest.clearAllMocks();
-  });
-  // TO DO: add more tests for the init method when we add functionality for apple/google pay
-  it('inits', async () => {
-    await expect(tyroSdk.init(defaultOptions)).resolves.not.toThrow();
   });
 
   it('inits and verifies the pay secret and returns the PayRequestSimplifiedStatus', async () => {

--- a/src/tests/WalletPaymentsContainer.spec.tsx
+++ b/src/tests/WalletPaymentsContainer.spec.tsx
@@ -36,6 +36,9 @@ const mockedFailedResult = {
   },
 } as WalletPaymentResult;
 
+const merchantIdentifier = 'merId';
+const merchantName = 'merName';
+
 describe('WalletPaymentsContainer', () => {
   let wrapper;
 
@@ -85,6 +88,7 @@ describe('WalletPaymentsContainer', () => {
               options: {
                 googlePay: {
                   enabled: true,
+                  merchantName,
                 },
               },
               styleProps: { showSupportedCards: false, googlePayButton: { buttonBorderRadius: 8 } },
@@ -109,6 +113,7 @@ describe('WalletPaymentsContainer', () => {
               options: {
                 googlePay: {
                   enabled: true,
+                  merchantName,
                 },
               },
               styleProps: { showSupportedCards: false },
@@ -134,6 +139,7 @@ describe('WalletPaymentsContainer', () => {
               options: {
                 googlePay: {
                   enabled: true,
+                  merchantName,
                 },
               },
               styleProps: {
@@ -158,6 +164,7 @@ describe('WalletPaymentsContainer', () => {
               options: {
                 googlePay: {
                   enabled: true,
+                  merchantName,
                 },
               },
               styleProps: {
@@ -184,6 +191,7 @@ describe('WalletPaymentsContainer', () => {
               options: {
                 googlePay: {
                   enabled: true,
+                  merchantName,
                 },
               },
               styleProps: { showSupportedCards: false },
@@ -213,6 +221,7 @@ describe('WalletPaymentsContainer', () => {
                 options: {
                   googlePay: {
                     enabled: true,
+                    merchantName,
                   },
                 },
                 styleProps: { showSupportedCards: false },
@@ -245,6 +254,7 @@ describe('WalletPaymentsContainer', () => {
                 options: {
                   googlePay: {
                     enabled: true,
+                    merchantName,
                   },
                 },
                 styleProps: { showSupportedCards: false },
@@ -281,6 +291,7 @@ describe('WalletPaymentsContainer', () => {
               options: {
                 googlePay: {
                   enabled: true,
+                  merchantName,
                 },
               },
               styleProps: { showSupportedCards: false },
@@ -340,6 +351,7 @@ describe('WalletPaymentsContainer', () => {
               options: {
                 applePay: {
                   enabled: true,
+                  merchantIdentifier,
                 },
               },
               styleProps: { showSupportedCards: false },
@@ -364,6 +376,7 @@ describe('WalletPaymentsContainer', () => {
               options: {
                 applePay: {
                   enabled: true,
+                  merchantIdentifier,
                 },
               },
               styleProps: { showSupportedCards: false },
@@ -393,6 +406,7 @@ describe('WalletPaymentsContainer', () => {
                 options: {
                   applePay: {
                     enabled: true,
+                    merchantIdentifier,
                   },
                 },
                 styleProps: { showSupportedCards: false },
@@ -425,6 +439,7 @@ describe('WalletPaymentsContainer', () => {
                 options: {
                   applePay: {
                     enabled: true,
+                    merchantIdentifier,
                   },
                 },
                 styleProps: { showSupportedCards: false },

--- a/src/utils/error-message.spec.ts
+++ b/src/utils/error-message.spec.ts
@@ -36,11 +36,13 @@ describe('errorMessage()', () => {
     expect(error.errorMessage).toEqual('Payment failed');
   });
 
-  it('Should return a message when no form', () => {
-    const error = errorMessage(TyroErrorMessages[ErrorMessageType.NO_FORM]);
-    expect(error.errorType).toEqual(ErrorMessageType.NO_FORM);
+  it('Should return a message when missing merchant details', () => {
+    const error = errorMessage(TyroErrorMessages[ErrorMessageType.MISSING_MERCHANT_CONFIG]);
+    expect(error.errorType).toEqual(ErrorMessageType.MISSING_MERCHANT_CONFIG);
     expect(error.errorCode).toEqual(undefined);
-    expect(error.errorMessage).toEqual('No form');
+    expect(error.errorMessage).toEqual(
+      'TyroProvider Failed to init due to missing Google and/or Apple Pay merchant details'
+    );
   });
   it('Should return a message when invalid card details', () => {
     const error = errorMessage(TyroErrorMessages[ErrorMessageType.INVALID_CARD_DETAILS]);


### PR DESCRIPTION
TyroProvider when it mounts will init and check the merchant details for Apple/Google Pay were provided in it's options if they have been enabled and then initialise if provided, otherwise it will set a tyroError informing the developer of the missing config